### PR TITLE
Replace runtime JSON serialization with Newtonsoft

### DIFF
--- a/Assets/Prefabs/Paredes/fence.prefab
+++ b/Assets/Prefabs/Paredes/fence.prefab
@@ -39,7 +39,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 701448701099452507}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9585d8ca2c061b245bb7cab171b3b75a, type: 3}
   m_Name: 
@@ -504,7 +504,7 @@ MonoBehaviour:
   ResizeActions: {fileID: 3508726404937098491}
   RotateActions: {fileID: 3625940384969753416}
   ActionManager: {fileID: 8867161354304716004}
-  CanvasManager: {fileID: 5132284406578706638}
+  CanvasManager: {fileID: 8464144207830135850}
   objectToRotate: {fileID: 5958407088867369703}
   rotationSpeed: 45
 --- !u!65 &8925927855141749033

--- a/Assets/Samples/XR Interaction Toolkit/3.0.4/Starter Assets/Scripts/ObjectSpawner.cs
+++ b/Assets/Samples/XR Interaction Toolkit/3.0.4/Starter Assets/Scripts/ObjectSpawner.cs
@@ -10,6 +10,8 @@ namespace UnityEngine.XR.Interaction.Toolkit.Samples.StarterAssets
     /// </summary>
     public class ObjectSpawner : MonoBehaviour
     {
+        const float k_DefaultSurfaceOffset = 0.005f;
+
         [SerializeField]
         [Tooltip("The camera that objects will face when spawned. If not set, defaults to the main camera.")]
         Camera m_CameraToFace;
@@ -299,10 +301,13 @@ namespace UnityEngine.XR.Interaction.Toolkit.Samples.StarterAssets
         static Vector3 GetSpawnPosition(GameObject spawnedObject, Vector3 spawnPoint, Vector3 spawnNormal)
         {
             var placementOffset = spawnedObject.GetComponent<SurfacePlacementOffset>();
-            if (placementOffset == null || spawnNormal.sqrMagnitude <= Mathf.Epsilon)
+            if (spawnNormal.sqrMagnitude <= Mathf.Epsilon)
                 return spawnPoint;
 
-            return spawnPoint + spawnNormal.normalized * placementOffset.offset;
+            float offset = placementOffset != null
+                ? placementOffset.offset
+                : k_DefaultSurfaceOffset;
+            return spawnPoint + spawnNormal.normalized * offset;
         }
 
         static void ClosePlacementMenus(GameObject spawnedObject)

--- a/Assets/Scripts/APIController.cs
+++ b/Assets/Scripts/APIController.cs
@@ -250,16 +250,16 @@ public class ApiController : MonoBehaviour
     {
 
         // Convertir el objeto a un string JSON
-        string jsonData = JsonUtility.ToJson(registerData);
+        string jsonData = JsonConvert.SerializeObject(registerData);
 
         StartCoroutine(PostRequest(baseUrl + "/users", jsonData, onSuccess: (jsonResponse) =>
         {
-            APIResponse<UserData> apiResponse = JsonUtility.FromJson<APIResponse<UserData>>(jsonResponse);
+            APIResponse<UserData> apiResponse = JsonConvert.DeserializeObject<APIResponse<UserData>>(jsonResponse);
             UIController.Instance.ScreenHandler("Login");
             onSuccess?.Invoke();
         }, onError: (jsonResponse) =>
         {
-            APIResponse<UserData> apiResponse = JsonUtility.FromJson<APIResponse<UserData>>(jsonResponse);
+            APIResponse<UserData> apiResponse = JsonConvert.DeserializeObject<APIResponse<UserData>>(jsonResponse);
             onError.Invoke(apiResponse.message);
         }));
     }
@@ -267,7 +267,7 @@ public class ApiController : MonoBehaviour
     public void Login(LoginData loginData, System.Action onSuccess, System.Action<string> onError)
     {
         // Convertir el objeto a un string JSON
-        string jsonData = JsonUtility.ToJson(loginData);
+        string jsonData = JsonConvert.SerializeObject(loginData);
 
         StartCoroutine(PostRequest(baseUrl + "/auth/login", jsonData, onSuccess: (jsonResponse) =>
         {
@@ -316,13 +316,13 @@ public class ApiController : MonoBehaviour
     {
 
         // Convertir el objeto a un string JSON
-        string jsonData = JsonUtility.ToJson(updateUserData);
+        string jsonData = JsonConvert.SerializeObject(updateUserData);
 
         Debug.Log(jsonData);
 
         StartCoroutine(PatchRequest(baseUrl + "/users/" + UIController.Instance.UserData.username, jsonData, onSuccess: (jsonResponse) =>
         {
-            APIResponse<UserData> apiResponse = JsonUtility.FromJson<APIResponse<UserData>>(jsonResponse);
+            APIResponse<UserData> apiResponse = JsonConvert.DeserializeObject<APIResponse<UserData>>(jsonResponse);
             UIController.Instance.UserData = apiResponse?.data;
             onSuccess?.Invoke();
         }, onError: (jsonResponse) =>
@@ -387,7 +387,7 @@ public class ApiController : MonoBehaviour
             experienceLevel = experienceLevel != 0 ? experienceLevel : (int)ExperienceLevel.Intermediate,
         };
 
-        string jsonData = JsonUtility.ToJson(tutorialData);
+        string jsonData = JsonConvert.SerializeObject(tutorialData);
         StartCoroutine(PostRequest(baseUrl + "/openai", jsonData, onSuccess: (jsonResponse) =>
         {
             APIResponse<Guide> apiResponse = JsonConvert.DeserializeObject<APIResponse<Guide>>(jsonResponse);
@@ -495,13 +495,11 @@ public class ApiController : MonoBehaviour
 
     public void CreateUserModel(UserModelData userModelData, System.Action<UserModelData> onSuccess, System.Action<string> onError)
     {
-        // Convertir el objeto a un string JSON
-        // string jsonGuide = JsonUtility.ToJson(userModelData.guide);
-        string jsonData = JsonUtility.ToJson(userModelData);
+        string jsonData = JsonConvert.SerializeObject(userModelData);
 
         StartCoroutine(PostRequest(baseUrl + "/userModels", jsonData, onSuccess: (jsonResponse) =>
         {
-            APIResponse<UserModelData> apiResponse = JsonUtility.FromJson<APIResponse<UserModelData>>(jsonResponse);
+            APIResponse<UserModelData> apiResponse = JsonConvert.DeserializeObject<APIResponse<UserModelData>>(jsonResponse);
             UIController.Instance.UserModelData = apiResponse?.data;
             onSuccess?.Invoke(apiResponse.data);
         }, onError: (jsonResponse) =>
@@ -515,11 +513,11 @@ public class ApiController : MonoBehaviour
     {
 
         // Convertir el objeto a un string JSON
-        string jsonData = JsonUtility.ToJson(updateUserModelData);
+        string jsonData = JsonConvert.SerializeObject(updateUserModelData);
 
         StartCoroutine(PatchRequest(baseUrl + "/userModels/" + UIController.Instance.UserModelData.id, jsonData, onSuccess: (jsonResponse) =>
         {
-            APIResponse<UserModelData> apiResponse = JsonUtility.FromJson<APIResponse<UserModelData>>(jsonResponse);
+            APIResponse<UserModelData> apiResponse = JsonConvert.DeserializeObject<APIResponse<UserModelData>>(jsonResponse);
             UIController.Instance.UserModelData = apiResponse?.data;
             onSuccess?.Invoke();
         }, onError: (jsonResponse) =>

--- a/Assets/Scripts/APIController.cs
+++ b/Assets/Scripts/APIController.cs
@@ -674,7 +674,7 @@ public class ApiController : MonoBehaviour
 
     public void SaveConversation(ConversationPostData conversationPostData, System.Action<ConversationData> onSuccess, System.Action<string> onError)
     {
-        string conversationData = JsonUtility.ToJson(conversationPostData);
+        string conversationData = JsonConvert.SerializeObject(conversationPostData);
         StartCoroutine(PostRequest(baseUrl + "/conversation", conversationData, onSuccess: (jsonResponse) =>
         {
             APIResponse<ConversationData> apiResponse = JsonConvert.DeserializeObject<APIResponse<ConversationData>>(jsonResponse);
@@ -689,7 +689,7 @@ public class ApiController : MonoBehaviour
 
     public void SaveMessages(ConversationMessagePostData conversationMessagesPostData, System.Action<List<ConversationMessageData>> onSuccess, System.Action<string> onError)
     {
-        string conversationMessagesData = JsonUtility.ToJson(conversationMessagesPostData);
+        string conversationMessagesData = JsonConvert.SerializeObject(conversationMessagesPostData);
         StartCoroutine(PostRequest(baseUrl + "/conversationMessage/all", conversationMessagesData, onSuccess: (jsonResponse) =>
         {
             Debug.Log("Crear mensajes de la conver");

--- a/Assets/Scripts/CanvasManager.cs
+++ b/Assets/Scripts/CanvasManager.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using DG.Tweening;
 using System.ComponentModel.Design;
@@ -15,6 +14,10 @@ using UnityEngine.XR.Interaction.Toolkit.Samples.StarterAssets;
 
 public class CanvasManager : MonoBehaviour, IModelCanvasController
 {
+    private const string ModelActionsMenu = "modelActions";
+    private const string RotateActionsMenu = "rotateActions";
+    private const string MoveActionsMenu = "moveActions";
+    private const string ResizeActionsMenu = "resizeActions";
 
     [SerializeField] private GameObject modelActions;
     [SerializeField] private GameObject resizeActions;
@@ -30,7 +33,6 @@ public class CanvasManager : MonoBehaviour, IModelCanvasController
     // private GameObject pivotContainer;
     // public float lengthToAdd = 0.01f;
     // private float resizeAmount = 0.01f;
-    List<string> menu = new() { "modelActions", "rotateActions", "moveActions", "resizeActions" };
     private string activeMenu;
     private string direction;
     private float resizeAmount = 0.01f;
@@ -104,7 +106,7 @@ public class CanvasManager : MonoBehaviour, IModelCanvasController
         HideMenu(resizeActions);
         HideMenu(rotateActions);
         HideMenu(moveActions);
-        activeMenu = menu[0]; // modelActions
+        activeMenu = ModelActionsMenu;
     }
     public void ActivateResizeCanvas()
     {
@@ -114,7 +116,7 @@ public class CanvasManager : MonoBehaviour, IModelCanvasController
         HideMenu(modelActions);
         HideMenu(rotateActions);
         HideMenu(moveActions);
-        activeMenu = menu[3]; // resizeActions
+        activeMenu = ResizeActionsMenu;
     }
     public void ActivateRotateCanvas()
     {
@@ -123,7 +125,7 @@ public class CanvasManager : MonoBehaviour, IModelCanvasController
         HideMenu(modelActions);
         HideMenu(resizeActions);
         HideMenu(moveActions);
-        activeMenu = menu[1]; // rotateActions
+        activeMenu = RotateActionsMenu;
     }
 
     public void ActivateMoveCanvas()
@@ -133,7 +135,7 @@ public class CanvasManager : MonoBehaviour, IModelCanvasController
         HideMenu(modelActions);
         HideMenu(resizeActions);
         HideMenu(rotateActions);
-        activeMenu = menu[2]; // moveActions
+        activeMenu = MoveActionsMenu;
     }
 
     public void HideCanvas()
@@ -142,7 +144,7 @@ public class CanvasManager : MonoBehaviour, IModelCanvasController
         HideMenu(resizeActions);
         HideMenu(rotateActions);
         HideMenu(moveActions);
-        activeMenu = menu[0]; // modelActions
+        activeMenu = ModelActionsMenu;
     }
 
     private static void HideMenu(GameObject actions)
@@ -404,15 +406,15 @@ public class CanvasManager : MonoBehaviour, IModelCanvasController
     }
     public void CancelAction()
     {
-        if (activeMenu == "rotateActions")
+        if (activeMenu == RotateActionsMenu)
         {
             objectReference.transform.rotation = previousRotation; //Funciona
         }
-        else if (activeMenu == "moveActions")
+        else if (activeMenu == MoveActionsMenu)
         {
             objectReference.transform.position = previousPosition; //Funciona
         }
-        else if (activeMenu == "resizeActions")
+        else if (activeMenu == ResizeActionsMenu)
         {
             objectReference.transform.position = previousPosition; //Funciona
             objectReference.transform.localScale = previousLocalScale; //Funciona

--- a/Assets/Scripts/CanvasManager.cs
+++ b/Assets/Scripts/CanvasManager.cs
@@ -100,100 +100,39 @@ public class CanvasManager : MonoBehaviour, IModelCanvasController
 
     public void ActivateModelCanvas()
     {
-        modelActions.transform.GetChild(0).transform.DOScale(new Vector3(1, 1, 1), 0.3f);
-        modelActions.transform.GetChild(1).transform.DOScale(new Vector3(1, 1, 1), 0.3f);
-        modelActions.transform.GetChild(2).transform.DOScale(new Vector3(1, 1, 1), 0.3f);
-        modelActions.transform.GetChild(3).transform.DOScale(new Vector3(1, 1, 1), 0.3f);
-        modelActions.transform.GetChild(4).transform.DOScale(new Vector3(1, 1, 1), 0.3f);
-        modelActions.transform.GetChild(5).transform.DOScale(new Vector3(1, 1, 1), 0.3f);
-
-        if (activeMenu == "resizeActions")
-        {
-            resizeActions.transform.GetChild(0).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
-            resizeActions.transform.GetChild(1).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
-            resizeActions.transform.GetChild(2).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
-            resizeActions.transform.GetChild(3).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
-            resizeActions.transform.GetChild(4).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
-            resizeActions.transform.GetChild(5).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
-            resizeActions.transform.GetChild(6).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
-            resizeActions.transform.GetChild(7).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
-        }
-        if (activeMenu == "rotateActions")
-        {
-            rotateActions.transform.GetChild(0).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
-            rotateActions.transform.GetChild(1).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
-            rotateActions.transform.GetChild(2).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
-            rotateActions.transform.GetChild(3).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
-            rotateActions.transform.GetChild(4).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
-        }
-        if (activeMenu == "moveActions")
-        {
-            moveActions.transform.GetChild(0).transform.DOScale(new Vector3(0, 0, 0), 0.3f);
-            moveActions.transform.GetChild(1).transform.DOScale(new Vector3(0, 0, 0), 0.3f);
-            moveActions.transform.GetChild(2).transform.DOScale(new Vector3(0, 0, 0), 0.3f);
-            moveActions.transform.GetChild(3).transform.DOScale(new Vector3(0, 0, 0), 0.3f);
-            moveActions.transform.GetChild(4).transform.DOScale(new Vector3(0, 0, 0), 0.3f);
-            moveActions.transform.GetChild(5).transform.DOScale(new Vector3(0, 0, 0), 0.3f);
-            moveActions.transform.GetChild(6).transform.DOScale(new Vector3(0, 0, 0), 0.3f);
-        }
+        ShowMenu(modelActions);
+        HideMenu(resizeActions);
+        HideMenu(rotateActions);
+        HideMenu(moveActions);
         activeMenu = menu[0]; // modelActions
     }
     public void ActivateResizeCanvas()
     {
         previousPosition = objectReference.transform.position;
         previousLocalScale = objectReference.transform.localScale;
-        resizeActions.transform.GetChild(0).transform.DOScale(new Vector3(1, 1, 1), 0.3f);
-        resizeActions.transform.GetChild(1).transform.DOScale(new Vector3(1, 1, 1), 0.3f);
-        resizeActions.transform.GetChild(2).transform.DOScale(new Vector3(1, 1, 1), 0.3f);
-        resizeActions.transform.GetChild(3).transform.DOScale(new Vector3(1, 1, 1), 0.3f);
-        resizeActions.transform.GetChild(4).transform.DOScale(new Vector3(1, 1, 1), 0.3f);
-        resizeActions.transform.GetChild(5).transform.DOScale(new Vector3(1, 1, 1), 0.3f);
-        resizeActions.transform.GetChild(6).transform.DOScale(new Vector3(1, 1, 1), 0.5f);
-        resizeActions.transform.GetChild(7).transform.DOScale(new Vector3(1, 1, 1), 0.5f);
-
-        modelActions.transform.GetChild(0).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
-        modelActions.transform.GetChild(1).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
-        modelActions.transform.GetChild(2).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
-        modelActions.transform.GetChild(3).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
-        modelActions.transform.GetChild(4).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
-        modelActions.transform.GetChild(5).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
+        ShowMenu(resizeActions);
+        HideMenu(modelActions);
+        HideMenu(rotateActions);
+        HideMenu(moveActions);
         activeMenu = menu[3]; // resizeActions
     }
     public void ActivateRotateCanvas()
     {
         previousRotation = objectReference.transform.rotation;
-        rotateActions.transform.GetChild(0).transform.DOScale(new Vector3(1, 1, 1), 0.3f);
-        rotateActions.transform.GetChild(1).transform.DOScale(new Vector3(1, 1, 1), 0.3f);
-        rotateActions.transform.GetChild(2).transform.DOScale(new Vector3(1, 1, 1), 0.3f);
-        rotateActions.transform.GetChild(3).transform.DOScale(new Vector3(1, 1, 1), 0.3f);
-        rotateActions.transform.GetChild(4).transform.DOScale(new Vector3(1, 1, 1), 0.3f);
-
-        modelActions.transform.GetChild(0).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
-        modelActions.transform.GetChild(1).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
-        modelActions.transform.GetChild(2).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
-        modelActions.transform.GetChild(3).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
-        modelActions.transform.GetChild(4).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
-        modelActions.transform.GetChild(5).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
+        ShowMenu(rotateActions);
+        HideMenu(modelActions);
+        HideMenu(resizeActions);
+        HideMenu(moveActions);
         activeMenu = menu[1]; // rotateActions
     }
 
     public void ActivateMoveCanvas()
     {
         previousPosition = objectReference.transform.position;
-        moveActions.transform.GetChild(0).transform.DOScale(new Vector3(1, 1, 1), 0.3f);
-        moveActions.transform.GetChild(1).transform.DOScale(new Vector3(1, 1, 1), 0.3f);
-        moveActions.transform.GetChild(2).transform.DOScale(new Vector3(1, 1, 1), 0.3f);
-        moveActions.transform.GetChild(3).transform.DOScale(new Vector3(1, 1, 1), 0.3f);
-        moveActions.transform.GetChild(4).transform.DOScale(new Vector3(1, 1, 1), 0.3f);
-        moveActions.transform.GetChild(5).transform.DOScale(new Vector3(1, 1, 1), 0.3f);
-        moveActions.transform.GetChild(6).transform.DOScale(new Vector3(1, 1, 1), 0.3f);
-
-        modelActions.transform.GetChild(0).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
-        modelActions.transform.GetChild(1).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
-        modelActions.transform.GetChild(2).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
-        modelActions.transform.GetChild(3).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
-        modelActions.transform.GetChild(4).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
-        modelActions.transform.GetChild(5).transform.DOScale(new Vector3(0, 0, 0), 0.5f);
+        ShowMenu(moveActions);
+        HideMenu(modelActions);
+        HideMenu(resizeActions);
+        HideMenu(rotateActions);
         activeMenu = menu[2]; // moveActions
     }
 
@@ -213,6 +152,15 @@ public class CanvasManager : MonoBehaviour, IModelCanvasController
 
         foreach (Transform action in actions.transform)
             action.DOScale(Vector3.zero, 0.3f);
+    }
+
+    private static void ShowMenu(GameObject actions)
+    {
+        if (actions == null)
+            return;
+
+        foreach (Transform action in actions.transform)
+            action.DOScale(Vector3.one, 0.3f);
     }
 
     public void RotateRightAction()

--- a/Assets/Scripts/UIController.cs
+++ b/Assets/Scripts/UIController.cs
@@ -316,12 +316,12 @@ public class UIController : MonoBehaviour
             PlayerPrefs.SetInt("spawnOptionId", objectSpawner.spawnOptionId);
         if (UserData != null)
         {
-            string userJsonData = JsonUtility.ToJson(UserData);
+            string userJsonData = JsonConvert.SerializeObject(UserData);
             PlayerPrefs.SetString("userData", userJsonData);
         }
         if (ModelData != null)
         {
-            string modelJsonData = JsonUtility.ToJson(ModelData);
+            string modelJsonData = JsonConvert.SerializeObject(ModelData);
             PlayerPrefs.SetString("modelData", modelJsonData);
         }
         if (ConversationsData != null)
@@ -348,14 +348,14 @@ public class UIController : MonoBehaviour
         if (objectSpawner != null)
             objectSpawner.spawnOptionId = PlayerPrefs.GetInt("spawnOptionId", -1);
         string userJsonData = PlayerPrefs.GetString("userData", "{}");
-        UserData = JsonUtility.FromJson<UserData>(userJsonData);
+        UserData = DeserializeOrDefault<UserData>(userJsonData);
         if (!LoggedIn || UserData == null || UserData.id <= 0)
         {
             if (LoggedIn) ClearSession();
             UserData = null;
         }
         string modelJsonData = PlayerPrefs.GetString("modelData", "{}");
-        ModelData = JsonUtility.FromJson<ModelData>(modelJsonData);
+        ModelData = DeserializeOrDefault<ModelData>(modelJsonData);
         string conversationsJsonData = PlayerPrefs.GetString("conversationsData", "[]");
         ConversationsData = DeserializeConversations(conversationsJsonData);
         currentConversationId = PlayerPrefs.GetInt("currentConversationId", -1);
@@ -379,6 +379,20 @@ public class UIController : MonoBehaviour
         catch (JsonException)
         {
             return new List<ConversationData>();
+        }
+    }
+
+    public static T DeserializeOrDefault<T>(string json) where T : class
+    {
+        if (string.IsNullOrWhiteSpace(json)) return null;
+
+        try
+        {
+            return JsonConvert.DeserializeObject<T>(json);
+        }
+        catch (JsonException)
+        {
+            return null;
         }
     }
 

--- a/Assets/Scripts/UIController.cs
+++ b/Assets/Scripts/UIController.cs
@@ -5,6 +5,7 @@ using UnityEngine.SceneManagement;
 using UnityEngine;
 using UnityEngine.InputSystem.EnhancedTouch;
 using UnityEngine.XR.Interaction.Toolkit.Samples.StarterAssets;
+using Newtonsoft.Json;
 
 
 public class UIController : MonoBehaviour
@@ -325,7 +326,7 @@ public class UIController : MonoBehaviour
         }
         if (ConversationsData != null)
         {
-            string conversationsJsonData = JsonUtility.ToJson(ConversationsData);
+            string conversationsJsonData = SerializeConversations(ConversationsData);
             PlayerPrefs.SetString("conversationsData", conversationsJsonData);
         }
         if (currentConversationId != -1)
@@ -355,9 +356,30 @@ public class UIController : MonoBehaviour
         }
         string modelJsonData = PlayerPrefs.GetString("modelData", "{}");
         ModelData = JsonUtility.FromJson<ModelData>(modelJsonData);
-        string conversationsJsonData = PlayerPrefs.GetString("conversationsData", "{}");
-        ConversationsData = JsonUtility.FromJson<List<ConversationData>>(conversationsJsonData);
+        string conversationsJsonData = PlayerPrefs.GetString("conversationsData", "[]");
+        ConversationsData = DeserializeConversations(conversationsJsonData);
         currentConversationId = PlayerPrefs.GetInt("currentConversationId", -1);
+    }
+
+    public static string SerializeConversations(List<ConversationData> conversations)
+    {
+        return JsonConvert.SerializeObject(conversations ?? new List<ConversationData>());
+    }
+
+    public static List<ConversationData> DeserializeConversations(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return new List<ConversationData>();
+
+        try
+        {
+            return JsonConvert.DeserializeObject<List<ConversationData>>(json)
+                ?? new List<ConversationData>();
+        }
+        catch (JsonException)
+        {
+            return new List<ConversationData>();
+        }
     }
 
     public bool HasValidSession()
@@ -389,6 +411,7 @@ public class UIController : MonoBehaviour
         PlayerPrefs.DeleteKey("accessToken");
         PlayerPrefs.DeleteKey("accessTokenExpiresAt");
         PlayerPrefs.DeleteKey("userData");
+        PlayerPrefs.DeleteKey("conversationsData");
         PlayerPrefs.DeleteKey("currentConversationId");
         PlayerPrefs.SetInt("loggedIn", 0);
         PlayerPrefs.Save();

--- a/Assets/Tests/EditMode/ConversationPersistenceTests.cs
+++ b/Assets/Tests/EditMode/ConversationPersistenceTests.cs
@@ -1,13 +1,29 @@
 using System;
 using System.Collections;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using NUnit.Framework;
+using UnityEngine;
 
 namespace BuildeAR.Tests.EditMode
 {
     public class ConversationPersistenceTests
     {
+        [Test]
+        public void RuntimeSources_UseNewtonsoftInsteadOfUnitySerializer()
+        {
+            string testsSegment = $"{Path.DirectorySeparatorChar}Tests{Path.DirectorySeparatorChar}";
+            string legacySerializer = "Json" + "Utility";
+            string[] offenders = Directory
+                .GetFiles(Application.dataPath, "*.cs", SearchOption.AllDirectories)
+                .Where(path => !path.Contains(testsSegment))
+                .Where(path => File.ReadAllText(path).Contains(legacySerializer))
+                .ToArray();
+
+            Assert.That(offenders, Is.Empty);
+        }
+
         [Test]
         public void NewtonsoftPersistence_RoundTripsRootConversationList()
         {

--- a/Assets/Tests/EditMode/ConversationPersistenceTests.cs
+++ b/Assets/Tests/EditMode/ConversationPersistenceTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+
+namespace BuildeAR.Tests.EditMode
+{
+    public class ConversationPersistenceTests
+    {
+        [Test]
+        public void NewtonsoftPersistence_RoundTripsRootConversationList()
+        {
+            Type controllerType = FindType("UIController");
+            Type conversationType = FindType("ConversationData");
+            Type listType = typeof(System.Collections.Generic.List<>).MakeGenericType(
+                conversationType
+            );
+            IList conversations = (IList)Activator.CreateInstance(listType);
+            object conversation = Activator.CreateInstance(conversationType);
+            conversationType.GetField("id").SetValue(conversation, 42);
+            conversationType.GetField("user_id").SetValue(conversation, 7);
+            conversations.Add(conversation);
+
+            MethodInfo serialize = controllerType.GetMethod(
+                "SerializeConversations",
+                BindingFlags.Public | BindingFlags.Static
+            );
+            MethodInfo deserialize = controllerType.GetMethod(
+                "DeserializeConversations",
+                BindingFlags.Public | BindingFlags.Static
+            );
+            string json = (string)serialize.Invoke(null, new object[] { conversations });
+            IList restored = (IList)deserialize.Invoke(null, new object[] { json });
+
+            Assert.That(json, Does.StartWith("["));
+            Assert.That(restored.Count, Is.EqualTo(1));
+            Assert.That(
+                conversationType.GetField("id").GetValue(restored[0]),
+                Is.EqualTo(42)
+            );
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("{}")]
+        [TestCase("not-json")]
+        public void InvalidLegacyConversationData_ReturnsEmptyList(string json)
+        {
+            Type controllerType = FindType("UIController");
+            MethodInfo deserialize = controllerType.GetMethod(
+                "DeserializeConversations",
+                BindingFlags.Public | BindingFlags.Static
+            );
+            IList restored = (IList)deserialize.Invoke(null, new object[] { json });
+
+            Assert.That(restored, Is.Not.Null);
+            Assert.That(restored.Count, Is.Zero);
+        }
+
+        private static Type FindType(string typeName)
+        {
+            Type type = AppDomain.CurrentDomain
+                .GetAssemblies()
+                .Select(assembly => assembly.GetType(typeName))
+                .FirstOrDefault(candidate => candidate != null);
+
+            Assert.That(type, Is.Not.Null, $"No se encontró el tipo {typeName}.");
+            return type;
+        }
+    }
+}

--- a/Assets/Tests/EditMode/ConversationPersistenceTests.cs.meta
+++ b/Assets/Tests/EditMode/ConversationPersistenceTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9aa8fe54ba354e77ad65bf1c92ad8586

--- a/Assets/Tests/EditMode/FavoriteDeletionTests.cs
+++ b/Assets/Tests/EditMode/FavoriteDeletionTests.cs
@@ -24,7 +24,7 @@ namespace BuildeAR.Tests.EditMode
             Assert.That(createFavorite.Success, Is.True);
             Assert.That(createFavorite.Value, Does.Contain("user_id = favoriteData.user_id"));
             Assert.That(createFavorite.Value, Does.Contain("model_id = favoriteData.model_id"));
-            Assert.That(createFavorite.Value, Does.Not.Contain("JsonUtility.ToJson(favoriteData)"));
+            Assert.That(createFavorite.Value, Does.Contain("JsonConvert.SerializeObject"));
             Assert.That(createFavorite.Value, Does.Contain("onSuccess?.Invoke()"));
         }
 

--- a/Assets/Tests/EditMode/ModelControlsTests.cs
+++ b/Assets/Tests/EditMode/ModelControlsTests.cs
@@ -14,6 +14,7 @@ namespace BuildeAR.Tests.EditMode
             );
 
             Assert.That(source, Does.Not.Contain(".GetChild("));
+            Assert.That(source, Does.Not.Contain("menu["));
             Assert.That(source, Does.Contain("ShowMenu(modelActions);"));
             Assert.That(source, Does.Contain("foreach (Transform action in actions.transform)"));
             Assert.That(source, Does.Contain("if (actions == null)"));

--- a/Assets/Tests/EditMode/ModelControlsTests.cs
+++ b/Assets/Tests/EditMode/ModelControlsTests.cs
@@ -1,0 +1,22 @@
+using System.IO;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace BuildeAR.Tests.EditMode
+{
+    public class ModelControlsTests
+    {
+        [Test]
+        public void CanvasMenus_IterateAvailableButtonsInsteadOfUsingFixedIndexes()
+        {
+            string source = File.ReadAllText(
+                Path.Combine(Application.dataPath, "Scripts", "CanvasManager.cs")
+            );
+
+            Assert.That(source, Does.Not.Contain(".GetChild("));
+            Assert.That(source, Does.Contain("ShowMenu(modelActions);"));
+            Assert.That(source, Does.Contain("foreach (Transform action in actions.transform)"));
+            Assert.That(source, Does.Contain("if (actions == null)"));
+        }
+    }
+}

--- a/Assets/Tests/EditMode/ModelControlsTests.cs
+++ b/Assets/Tests/EditMode/ModelControlsTests.cs
@@ -18,5 +18,20 @@ namespace BuildeAR.Tests.EditMode
             Assert.That(source, Does.Contain("foreach (Transform action in actions.transform)"));
             Assert.That(source, Does.Contain("if (actions == null)"));
         }
+
+        [Test]
+        public void XRInteractionToolkit_IncludesScreenSpaceCanvasNullGuard()
+        {
+            string manifest = File.ReadAllText(
+                Path.GetFullPath(
+                    Path.Combine(Application.dataPath, "..", "Packages", "manifest.json")
+                )
+            );
+
+            Assert.That(
+                manifest,
+                Does.Contain("\"com.unity.xr.interaction.toolkit\": \"3.0.8\"")
+            );
+        }
     }
 }

--- a/Assets/Tests/EditMode/ModelControlsTests.cs.meta
+++ b/Assets/Tests/EditMode/ModelControlsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c9858adad8b44e9a97a084c0a769c852

--- a/Assets/Tests/EditMode/ObjectSpawnerCountTests.cs
+++ b/Assets/Tests/EditMode/ObjectSpawnerCountTests.cs
@@ -158,6 +158,28 @@ namespace BuildeAR.Tests.EditMode
         }
 
         [Test]
+        public void TrySpawnObject_WithoutPlacementSettings_AppliesDefaultSurfaceOffset()
+        {
+            ObjectSpawner spawner = CreateSpawner();
+            GameObject prefab = Track(new GameObject("Wall model prefab"));
+
+            spawner.objectPrefabs = new List<GameObject> { prefab };
+            spawner.objectPrefabsIndex = new List<int> { 6 };
+            spawner.spawnOptionId = 6;
+            spawner.spawnAsChildren = true;
+            spawner.onlySpawnInView = false;
+
+            Vector3 spawnPoint = new(1f, 2f, 3f);
+            bool spawned = spawner.TrySpawnObject(spawnPoint, Vector3.forward);
+
+            Assert.That(spawned, Is.True);
+            Assert.That(
+                spawner.transform.GetChild(0).position,
+                Is.EqualTo(spawnPoint + Vector3.forward * 0.005f)
+            );
+        }
+
+        [Test]
         public void CeramicPrefab_HasSurfaceOffsetToAvoidPlaneZFighting()
         {
             const string ceramicPath = "Assets/Prefabs/Pisos/Ceramic.prefab";
@@ -167,6 +189,29 @@ namespace BuildeAR.Tests.EditMode
             SurfacePlacementOffset placementOffset = ceramic.GetComponent<SurfacePlacementOffset>();
             Assert.That(placementOffset, Is.Not.Null);
             Assert.That(placementOffset.offset, Is.EqualTo(0.005f));
+        }
+
+        [Test]
+        public void WallPrefab_HasOnlyOneEnabledCanvasManager()
+        {
+            const string wallPath = "Assets/Prefabs/Paredes/fence.prefab";
+            GameObject wall = AssetDatabase.LoadAssetAtPath<GameObject>(wallPath);
+
+            Assert.That(wall, Is.Not.Null);
+            int enabledCanvasManagers = 0;
+            foreach (MonoBehaviour behaviour in wall.GetComponentsInChildren<MonoBehaviour>(true))
+            {
+                if (
+                    behaviour != null &&
+                    behaviour.enabled &&
+                    behaviour.GetType().Name == "CanvasManager"
+                )
+                {
+                    enabledCanvasManagers++;
+                }
+            }
+
+            Assert.That(enabledCanvasManagers, Is.EqualTo(1));
         }
 
         [Test]

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -18,7 +18,7 @@
     "com.unity.xr.arcore": "5.1.4",
     "com.unity.xr.arfoundation": "5.1.4",
     "com.unity.xr.arkit": "5.1.4",
-    "com.unity.xr.interaction.toolkit": "3.0.4",
+    "com.unity.xr.interaction.toolkit": "3.0.8",
     "com.unity.xr.management": "4.4.1",
     "com.utilities.async": "https://github.com/RageAgainstThePixel/com.utilities.async.git#upm",
     "com.utilities.audio": "https://github.com/RageAgainstThePixel/com.utilities.audio.git#upm",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -270,7 +270,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.xr.interaction.toolkit": {
-      "version": "3.0.4",
+      "version": "3.0.8",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
## Resumen

- Reemplaza JsonUtility por Newtonsoft.Json en la serialización del runtime.
- Corrige la persistencia y recuperación del historial de conversaciones.
- Mantiene los datos serializados de forma consistente entre sesiones.

## Orden recomendado

- Mergear primero el PR #
15
.
- Después de ese merge, GitHub recalculará este diff contra main y eliminará los cambios compartidos.

## Validación

- Probar guardado y carga del historial.
- Cerrar y volver a abrir la aplicación para confirmar persistencia.