### PR TITLE
feat: enable AR depth occlusion

### DIFF
--- a/Assets/Samples/XR Interaction Toolkit/3.0.4/AR Starter Assets/Prefabs/XR Origin (AR Rig).prefab
+++ b/Assets/Samples/XR Interaction Toolkit/3.0.4/AR Starter Assets/Prefabs/XR Origin (AR Rig).prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 2512387469002778328}
   - component: {fileID: 2512387469002778329}
   - component: {fileID: 2512387469002778310}
+  - component: {fileID: 8263514179883450840}
   - component: {fileID: 2512387469002778311}
   - component: {fileID: 8856633716983450840}
   m_Layer: 0
@@ -200,6 +201,23 @@ MonoBehaviour:
     m_Interactions: 
     m_SingletonActionBindings: []
     m_Flags: 0
+--- !u!114 &8263514179883450840
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2512387469002778309}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b15f82cc229284894964d2d30806969d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_HumanSegmentationStencilMode: 3
+  m_HumanSegmentationDepthMode: 2
+  m_EnvironmentDepthMode: 2
+  m_EnvironmentDepthTemporalSmoothing: 1
+  m_OcclusionPreferenceMode: 1
 --- !u!114 &8856633716983450840
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Tests/EditMode/MobileBuildSessionTests.cs
+++ b/Assets/Tests/EditMode/MobileBuildSessionTests.cs
@@ -63,6 +63,31 @@ namespace BuildeAR.Tests.EditMode
         }
 
         [Test]
+        public void ArCamera_RequestsDepthOcclusionWithSafePlatformFallback()
+        {
+            string arRigPrefab = ReadRuntimeSource(
+                "Samples",
+                "XR Interaction Toolkit",
+                "3.0.4",
+                "AR Starter Assets",
+                "Prefabs",
+                "XR Origin (AR Rig).prefab"
+            );
+
+            Assert.That(
+                arRigPrefab,
+                Does.Contain("guid: b15f82cc229284894964d2d30806969d")
+            );
+            Assert.That(arRigPrefab, Does.Contain("m_EnvironmentDepthMode: 2"));
+            Assert.That(
+                arRigPrefab,
+                Does.Contain("m_EnvironmentDepthTemporalSmoothing: 1")
+            );
+            Assert.That(arRigPrefab, Does.Contain("m_HumanSegmentationStencilMode: 3"));
+            Assert.That(arRigPrefab, Does.Contain("m_HumanSegmentationDepthMode: 2"));
+        }
+
+        [Test]
         public void BuildController_IsSceneLocalAndDoesNotDisableNewSceneObjectsManually()
         {
             string source = File.ReadAllText(


### PR DESCRIPTION
## Resumen
- habilita oclusión de profundidad en la cámara AR
- solicita profundidad del entorno con fallback seguro según el dispositivo
- conserva segmentación humana cuando la plataforma la soporta
- integra la prueba de oclusión con el flujo de escena única BuildUI

## Validación
- Unity 2022.3.14f1
- EditMode: 75/75 tests aprobados